### PR TITLE
Get examples running according to README

### DIFF
--- a/examples/runner/Cargo.toml
+++ b/examples/runner/Cargo.toml
@@ -17,8 +17,8 @@ serde = { version = "1", features = ["derive"] }
 xtra = { git = "https://github.com/Restioson/xtra", features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-bincode = "1"
-plugy = { path = "../../", default-features = false, features = ["runtime"] }
 tokio = { version = "1", features = ["full"] }
+plugy = { path = "../../", default-features = false, features = ["runtime"] }
+bincode = "1"
 reqwest = "0.11.18"
 xtra = { git = "https://github.com/Restioson/xtra", features = ["macros", "tokio"] }

--- a/examples/runner/Cargo.toml
+++ b/examples/runner/Cargo.toml
@@ -10,13 +10,13 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1"
 async-trait = "0.1"
 plugy = { path = "../../" }
 serde = { version = "1", features = ["derive"] }
 xtra = { git = "https://github.com/Restioson/xtra", features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-anyhow = "1"
 bincode = "1"
 plugy = { path = "../../", default-features = false, features = ["runtime"] }
 tokio = { version = "1", features = ["full"] }

--- a/examples/runner/Cargo.toml
+++ b/examples/runner/Cargo.toml
@@ -10,14 +10,15 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
+async-trait = "0.1"
 plugy = { path = "../../" }
 serde = { version = "1", features = ["derive"] }
+xtra = { git = "https://github.com/Restioson/xtra", features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["full"] }
-plugy = { path = "../../", default-features = false, features = ["runtime"] }
+anyhow = "1"
 bincode = "1"
+plugy = { path = "../../", default-features = false, features = ["runtime"] }
+tokio = { version = "1", features = ["full"] }
 reqwest = "0.11.18"
-xtra = { git = "https://github.com/Restioson/xtra", features = ["tokio", "macros"] }
-async-trait = "0.1"
+xtra = { git = "https://github.com/Restioson/xtra", features = ["macros", "tokio"] }

--- a/examples/runner/Cargo.toml
+++ b/examples/runner/Cargo.toml
@@ -21,4 +21,4 @@ tokio = { version = "1", features = ["full"] }
 plugy = { path = "../../", default-features = false, features = ["runtime"] }
 bincode = "1"
 reqwest = "0.11.18"
-xtra = { git = "https://github.com/Restioson/xtra", features = ["macros", "tokio"] }
+xtra = { git = "https://github.com/Restioson/xtra", features = ["tokio", "macros"] }

--- a/examples/runner/src/lib.rs
+++ b/examples/runner/src/lib.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+#[cfg(not(target_arch = "wasm32"))]
 use plugy::runtime::Plugin;
 use serde::{Deserialize, Serialize};
 use xtra::{Address, Handler};
@@ -12,6 +13,7 @@ pub struct Fetcher;
 
 #[plugy::macros::context(data = Addr)]
 impl Fetcher {
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn fetch(_: &mut plugy::runtime::Caller<'_, Plugin<Addr>>, url: String) -> String {
         reqwest::get(url).await.unwrap().text().await.unwrap()
     }

--- a/examples/runner/src/lib.rs
+++ b/examples/runner/src/lib.rs
@@ -13,7 +13,6 @@ pub struct Fetcher;
 
 #[plugy::macros::context(data = Addr)]
 impl Fetcher {
-    #[cfg(not(target_arch = "wasm32"))]
     pub async fn fetch(_: &mut plugy::runtime::Caller<'_, Plugin<Addr>>, url: String) -> String {
         reqwest::get(url).await.unwrap().text().await.unwrap()
     }


### PR DESCRIPTION
Hi there. Love the project!

In trying to run it locally, I saw the examples weren't building and running as described in the README.

<details>
  <summary>Example Logs</summary>

```
plugy/examples/foo-plugin
❯ cargo build --target wasm32-unknown-unknown
   Compiling plugy v0.3.1 (/Users/matchai/dev/plugy)
   Compiling runner v0.3.1 (/Users/matchai/dev/plugy/examples/runner)
error[E0432]: unresolved import `plugy::runtime`
 --> examples/runner/src/lib.rs:2:12
  |
2 | use plugy::runtime::Plugin;
  |            ^^^^^^^ could not find `runtime` in `plugy`

error[E0432]: unresolved import `async_trait`
 --> examples/runner/src/lib.rs:1:5
  |
1 | use async_trait::async_trait;
  |     ^^^^^^^^^^^ use of undeclared crate or module `async_trait`

error[E0432]: unresolved import `xtra`
 --> examples/runner/src/lib.rs:4:5
  |
4 | use xtra::{Address, Handler};
  |     ^^^^ use of undeclared crate or module `xtra`

error[E0433]: failed to resolve: use of undeclared crate or module `xtra`
  --> examples/runner/src/lib.rs:22:19
   |
22 | #[derive(Default, xtra::Actor)]
   |                   ^^^^ use of undeclared crate or module `xtra`

error[E0433]: failed to resolve: use of undeclared crate or module `xtra`
  --> examples/runner/src/lib.rs:33:57
   |
33 | ...x: &mut xtra::Context<Self>) {
   |            ^^^^ use of undeclared crate or module `xtra`

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `runner` (lib) due to 5 previous errors
```

</details>

The cause was missing dependencies in the wasm-32 build and an import from the `runtime` feature from within the plugin.

Here's a small PR getting things working as minimally as possible.